### PR TITLE
Add nameable shops and msg formatting

### DIFF
--- a/src/main/java/se/leddy231/playertrading/ShopMerchant.java
+++ b/src/main/java/se/leddy231/playertrading/ShopMerchant.java
@@ -19,11 +19,11 @@ public class ShopMerchant implements Merchant {
     @Nullable
     public PlayerEntity currentCustomer;
     public IShopBarrelEntity shopEntity;
-    // Trades that expire/are used up needs to be kept inte the trades list until
+    // Trades that expire/are used up needs to be kept in the trades list until
     // the screen is closed
     // Otherwise, the client game crashes
     public ShopTradeOffer[] oldTrades;
-    // Ignore inventory refresh while moving thins around in the inventory
+    // Ignore inventory refresh while moving things around in the inventory
     private boolean ignoreRefresh = false;
 
     public ShopMerchant(IShopBarrelEntity shopEntity) {
@@ -41,8 +41,8 @@ public class ShopMerchant implements Merchant {
     }
 
     @Override
-    public void setCurrentCustomer(@Nullable PlayerEntity var1) {
-        currentCustomer = var1;
+    public void setCurrentCustomer(@Nullable PlayerEntity player) {
+        currentCustomer = player;
     }
 
     @Nullable
@@ -51,12 +51,12 @@ public class ShopMerchant implements Merchant {
         return currentCustomer;
     }
 
-    public void openShop(PlayerEntity player) {
+    public void openShop(PlayerEntity player, String shopName) {
         setCurrentCustomer(player);
-        sendOffers(player, new LiteralText(SHOP_TITLE), 0);
+        sendOffers(player, new LiteralText(shopName != null ? shopName : SHOP_TITLE), 0);
     }
 
-    // Optimization: cache this and only refresh on barrel inventory changes
+    // TODO Optimization: cache this and only refresh on barrel inventory changes
     public TradeOfferList getOffers() {
         TradeOfferList list = new TradeOfferList();
         Inventory outputBarrel = shopEntity.getOutputBarrel();
@@ -133,10 +133,12 @@ public class ShopMerchant implements Merchant {
         if (ignoreRefresh)
             return;
         PlayerTrading.LOGGER.info("refresh");
-        int syncid = currentCustomer.currentScreenHandler.syncId;
-        currentCustomer.sendTradeOffers(syncid, getOffers(), 0, 0, this.isLeveledMerchant(), this.canRefreshTrades());
-        MerchantScreenHandlerAccessor accessor = (MerchantScreenHandlerAccessor) currentCustomer.currentScreenHandler;
-        accessor.getMerchantInventory().updateOffers();
+        if (currentCustomer != null) {
+            int syncid = currentCustomer.currentScreenHandler.syncId;
+            currentCustomer.sendTradeOffers(syncid, getOffers(), 0, 0, this.isLeveledMerchant(), this.canRefreshTrades());
+            MerchantScreenHandlerAccessor accessor = (MerchantScreenHandlerAccessor) currentCustomer.currentScreenHandler;
+            accessor.getMerchantInventory().updateOffers();
+        }
     }
 
     public void trade(TradeOffer var1) {

--- a/src/main/java/se/leddy231/playertrading/Utils.java
+++ b/src/main/java/se/leddy231/playertrading/Utils.java
@@ -5,6 +5,7 @@ import net.minecraft.inventory.Inventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.LiteralText;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
 
 public class Utils {
@@ -14,6 +15,13 @@ public class Utils {
 
     public static void sendMessage(PlayerEntity player, String text) {
         player.sendMessage(new LiteralText(text), false);
+    }
+
+    /**
+     * Send message method that supports formatting
+     */
+    public static void sendMessage(PlayerEntity player, LiteralText literalText) {
+        player.sendMessage(literalText, false);
     }
 
     public static boolean canStacksCombine(ItemStack first, ItemStack second) {

--- a/src/main/java/se/leddy231/playertrading/interfaces/IAugmentedBarrelEntity.java
+++ b/src/main/java/se/leddy231/playertrading/interfaces/IAugmentedBarrelEntity.java
@@ -11,7 +11,9 @@ public interface IAugmentedBarrelEntity {
 
     public abstract UUID getOwner();
 
-    public abstract void activate(PlayerEntity player, BarrelType signType);
+    public abstract String getShopName();
+
+    public abstract void activate(PlayerEntity player, BarrelType signType, String shopName);
 
     public abstract void onInventoryChange();
 }

--- a/src/main/java/se/leddy231/playertrading/mixin/BarrelBlockMixin.java
+++ b/src/main/java/se/leddy231/playertrading/mixin/BarrelBlockMixin.java
@@ -38,7 +38,7 @@ public class BarrelBlockMixin {
 			}
 			ci.setReturnValue(ActionResult.SUCCESS);
 			IShopBarrelEntity shop = (IShopBarrelEntity) barrelEntity;
-			shop.getShopMerchant().openShop(player);
+			shop.getShopMerchant().openShop(player, barrelEntity.getShopName());
 		}
 
 	}

--- a/src/main/java/se/leddy231/playertrading/mixin/SignEntityMixin.java
+++ b/src/main/java/se/leddy231/playertrading/mixin/SignEntityMixin.java
@@ -25,6 +25,10 @@ public class SignEntityMixin {
     public void createShop(ServerPlayerEntity player, final CallbackInfoReturnable<Boolean> callback) {
         SignBlockEntity signEntity = (SignBlockEntity) (Object) this;
         Text text = signEntity.getTextOnRow(0, false);
+
+        // Get shop name
+        Text shopName = signEntity.getTextOnRow(1, false);
+
         // Has shop tag on sign
         BarrelType type = BarrelType.fromSignTag(text.asString());
         if (type == BarrelType.NONE)
@@ -44,7 +48,8 @@ public class SignEntityMixin {
         // Sign is attached to a barrel
         if (!(barrelState.getBlock() instanceof BarrelBlock))
             return;
+
         IAugmentedBarrelEntity barrelEntity = (IAugmentedBarrelEntity) world.getBlockEntity(pos);
-        barrelEntity.activate(player, type);
+        barrelEntity.activate(player, type, shopName.asString());
     }
 }


### PR DESCRIPTION
This commit introduces nameable shops which will be displayed instead
of "Barrel shop". Shops are named by using the second row of the sign when
activated.
Messages now also have a color formatting to make them more clear, thus
allowing for the user to more easily understand if something good or bad happened.