### PR TITLE
Refresh inventory on barrel block break

### DIFF
--- a/src/main/java/se/leddy231/playertrading/ShopMerchant.java
+++ b/src/main/java/se/leddy231/playertrading/ShopMerchant.java
@@ -56,6 +56,12 @@ public class ShopMerchant implements Merchant {
         sendOffers(player, new LiteralText(SHOP_TITLE), 0);
     }
 
+    public void forceCloseShop() {
+        if (currentCustomer != null) {
+            currentCustomer.currentScreenHandler.close(currentCustomer);
+        }
+    }
+
     // Optimization: cache this and only refresh on barrel inventory changes
     public TradeOfferList getOffers() {
         TradeOfferList list = new TradeOfferList();

--- a/src/main/java/se/leddy231/playertrading/ShopMerchant.java
+++ b/src/main/java/se/leddy231/playertrading/ShopMerchant.java
@@ -132,7 +132,6 @@ public class ShopMerchant implements Merchant {
     public void refreshTrades() {
         if (ignoreRefresh)
             return;
-        PlayerTrading.LOGGER.info("refresh");
         int syncid = currentCustomer.currentScreenHandler.syncId;
         currentCustomer.sendTradeOffers(syncid, getOffers(), 0, 0, this.isLeveledMerchant(), this.canRefreshTrades());
         MerchantScreenHandlerAccessor accessor = (MerchantScreenHandlerAccessor) currentCustomer.currentScreenHandler;

--- a/src/main/java/se/leddy231/playertrading/mixin/BarrelBlockMixin.java
+++ b/src/main/java/se/leddy231/playertrading/mixin/BarrelBlockMixin.java
@@ -52,8 +52,11 @@ public class BarrelBlockMixin {
 			return;
 		}
 		IAugmentedBarrelEntity barrelEntity = (IAugmentedBarrelEntity) (Object) entity;
-		if (barrelEntity.getType() != BarrelType.NONE) {
+		if (barrelEntity.getType().isExpansionType()) {
 			barrelEntity.onInventoryChange();
+		}
+		if (barrelEntity.getType() == BarrelType.SHOP) {
+			((IShopBarrelEntity) barrelEntity).getShopMerchant().forceCloseShop();
 		}
 	}
 }

--- a/src/main/java/se/leddy231/playertrading/mixin/BarrelBlockMixin.java
+++ b/src/main/java/se/leddy231/playertrading/mixin/BarrelBlockMixin.java
@@ -18,6 +18,7 @@ import se.leddy231.playertrading.interfaces.IShopBarrelEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BarrelBlock.class)
@@ -40,6 +41,19 @@ public class BarrelBlockMixin {
 			IShopBarrelEntity shop = (IShopBarrelEntity) barrelEntity;
 			shop.getShopMerchant().openShop(player);
 		}
+	}
 
+	//Update inventory on block break
+	@Inject(at = @At("HEAD"), method = "onStateReplaced")
+	private void onUse(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved,
+			CallbackInfo ci) {
+		BlockEntity entity = world.getBlockEntity(pos);
+		if (!(entity instanceof BarrelBlockEntity)) {
+			return;
+		}
+		IAugmentedBarrelEntity barrelEntity = (IAugmentedBarrelEntity) (Object) entity;
+		if (barrelEntity.getType() != BarrelType.NONE) {
+			barrelEntity.onInventoryChange();
+		}
 	}
 }

--- a/src/main/java/se/leddy231/playertrading/mixin/BarrelEntityMixin.java
+++ b/src/main/java/se/leddy231/playertrading/mixin/BarrelEntityMixin.java
@@ -13,7 +13,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
 import se.leddy231.playertrading.*;
 import se.leddy231.playertrading.interfaces.IAugmentedBarrelEntity;

--- a/src/main/java/se/leddy231/playertrading/mixin/MerchantScreenHandlerMixin.java
+++ b/src/main/java/se/leddy231/playertrading/mixin/MerchantScreenHandlerMixin.java
@@ -26,7 +26,7 @@ public class MerchantScreenHandlerMixin {
 	private void onScreenClose(PlayerEntity player, CallbackInfo ci) {
         MerchantScreenHandlerAccessor accessor = (MerchantScreenHandlerAccessor) this;
         Merchant merchant = accessor.getMerchant();
-        if (accessor.getMerchant() instanceof ShopMerchant) {
+        if (merchant instanceof ShopMerchant) {
             ((ShopMerchant) merchant).onScreenClose();
         }
 	}


### PR DESCRIPTION
Breaking a connected barrel should immediately refresh the trades or close the shop so that nothing weird happens